### PR TITLE
fix java getting started

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -21,10 +21,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.openapitools</groupId>
-            <artifactId>openapi-java-client</artifactId>
-            <version>1.0</version>
-            <scope>compile</scope>
+            <groupId>com.piiano.vault</groupId>
+            <artifactId>openapi</artifactId>
+            <version>1.1.3</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/java/prepare.sh
+++ b/java/prepare.sh
@@ -2,20 +2,5 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-echo "Download openapi file"
-curl -o openapi.yaml https://piiano.com/docs/assets/openapi.yaml
-
-echo "Delete the old generated java SDK"
-[ -d "vault_java_sdk" ] && rm -r vault_java_sdk
-
-echo "Run openapi tools to create the java SDK"
-docker run --rm -u $(id -u):$(id -g) -v "${PWD}:/local" openapitools/openapi-generator-cli:v6.4.0 generate \
-    -i local/openapi.yaml \
-    -g java \
-    -o local/vault_java_sdk
-
-echo "Install java SDK"
-cd vault_java_sdk && mvn clean install
-
 echo "Build and install 'Getting started'"
-cd .. && mvn clean install -DskipTests
+mvn clean install -DskipTests

--- a/java/src/main/java/PvaultGettingStarted.java
+++ b/java/src/main/java/PvaultGettingStarted.java
@@ -1,11 +1,8 @@
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import org.openapitools.client.ApiClient;
-import org.openapitools.client.ApiException;
-import org.openapitools.client.Configuration;
-import org.openapitools.client.api.*;
-import org.openapitools.client.model.Collection;
-import org.openapitools.client.model.*;
+import com.piiano.vault.client.openapi.*;
+import com.piiano.vault.client.openapi.model.Collection;
+import com.piiano.vault.client.openapi.model.*;
 
 import java.util.*;
 
@@ -18,47 +15,12 @@ public class PvaultGettingStarted {
     public static final String HEALTH_PASS = "pass";
     public static final String JSON = "json";
     public static final String APP_FUNCTIONALITY_REASON = "AppFunctionality";
-    public static final String NO_ADHOC_REASON = "";
+    public static final String NO_ADHOC_REASON = null;
     public static final Set<String> NO_OPTIONS = emptySet();
     public static final String USE_DEFAULT_TTL = "";
     public static final String UNSAFE_OPTION = "unsafe"; // fetch all the properties
-    public static final String NO_TRANSACTION_ID=""; // Transaction ID is only relevant for advanced usage
+    public static final String NO_TRANSACTION_ID = null; // Transaction ID is only relevant for advanced usage
     public static final int PVAULT_ADDRESS = 8123;
-
-    public void run() throws Exception {
-
-        print("\n\n== Steps 1 + 2: Connect to Piiano vault and check status ==\n\n");
-        ApiClient pvaultClient = getApiClient();
-        checkPvaultStatus(pvaultClient);
-
-        print("\n\n== Step 3: Create a collection ==\n\n");
-        CollectionsApi collectionsApi = new CollectionsApi(pvaultClient);
-        CollectionPropertiesApi collectionpropapi = new CollectionPropertiesApi(pvaultClient);
-        // deleteCollection(collectionsApi);
-        verifyNoCollections(collectionpropapi);
-        createCollection(collectionsApi);
-
-        print("\n\n== Step 4: Add data ==\n\n");
-        ObjectsApi objectsApi = new ObjectsApi(pvaultClient);
-        List<UUID> customerIds = addData(objectsApi);
-
-        print("\n\n== Step 5: Tokenize data ==\n\n");
-        TokensApi tokensApi = new TokensApi(pvaultClient);
-        String token = tokenizeData(customerIds.get(0), tokensApi);
-
-        detokenizeToken(tokensApi, token);
-
-        print("\n\n== Step 6: Query your data ==\n\n");
-        queryAllObjectsWithPageSize(objectsApi);
-        queryPropertiesOfObjectsById(objectsApi, customerIds.get(0));
-        getTransformedPropertiesOfObjects(objectsApi, customerIds.get(0));
-
-        print("\n\n== Step 7: Delete data ==\n\n");
-        deleteToken(tokensApi, token);
-        deleteObject(objectsApi, customerIds.get(0));
-
-        print("Done!\n");
-    }
 
     private static void checkPvaultStatus(ApiClient pvaultClient) throws ApiException {
 
@@ -87,13 +49,12 @@ public class PvaultGettingStarted {
             List<Property> mp =
                     collectionpropApi.listCollectionProperties(COLLECTION_NAME, NO_OPTIONS);
             throw new RuntimeException("Collection " + COLLECTION_NAME + " already exists.\n" +
-                  "Recreate the Vault from scratch or uncomment deleteCollection()" +
-                  " in this code. Bailing out.\n");
+                    "Recreate the Vault from scratch or uncomment deleteCollection()" +
+                    " in this code. Bailing out.\n");
         } catch (ApiException e) {
             if (e.getCode() == 404) {
-                print("Collection "  + COLLECTION_NAME + " not found. Will create it");
-            }
-            else {
+                print("Collection " + COLLECTION_NAME + " not found. Will create it");
+            } else {
                 throw new ApiException(e);
             }
         }
@@ -109,7 +70,7 @@ public class PvaultGettingStarted {
 
         collection.addPropertiesItem(
                 buildProperty("ssn", "SSN", "Social security number",
-                true, false, true, false));
+                        true, false, true, false));
 
         collection.addPropertiesItem(
                 buildProperty("email", "EMAIL", "EMAIL",
@@ -175,7 +136,7 @@ public class PvaultGettingStarted {
         tokenizeRequest.setTags(ImmutableList.of("token_tag"));
 
         String token = tokensApi.tokenize(COLLECTION_NAME, APP_FUNCTIONALITY_REASON, List.of(tokenizeRequest),
-                                          USE_DEFAULT_TTL, NO_TRANSACTION_ID, NO_ADHOC_REASON, false).get(0).getTokenId();
+                USE_DEFAULT_TTL, NO_TRANSACTION_ID, NO_ADHOC_REASON, false).get(0).getTokenId();
         print("Token: ", token);
         return token;
     }
@@ -292,15 +253,49 @@ public class PvaultGettingStarted {
         PvaultGettingStarted pvaultGettingStarted = new PvaultGettingStarted();
         try {
             pvaultGettingStarted.run();
-        } catch (org.openapitools.client.ApiException apiException) {
+        } catch (ApiException apiException) {
             if (apiException.getMessage().contains("java.net.ConnectException")) {
                 print(apiException.getMessage() + "\n\nIs the Vault running?\n");
-            }
-            else {
+            } else {
                 throw new RuntimeException(apiException);
             }
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public void run() throws Exception {
+
+        print("\n\n== Steps 1 + 2: Connect to Piiano vault and check status ==\n\n");
+        ApiClient pvaultClient = getApiClient();
+        checkPvaultStatus(pvaultClient);
+
+        print("\n\n== Step 3: Create a collection ==\n\n");
+        CollectionsApi collectionsApi = new CollectionsApi(pvaultClient);
+        CollectionPropertiesApi collectionpropapi = new CollectionPropertiesApi(pvaultClient);
+        // deleteCollection(collectionsApi);
+        verifyNoCollections(collectionpropapi);
+        createCollection(collectionsApi);
+
+        print("\n\n== Step 4: Add data ==\n\n");
+        ObjectsApi objectsApi = new ObjectsApi(pvaultClient);
+        List<UUID> customerIds = addData(objectsApi);
+
+        print("\n\n== Step 5: Tokenize data ==\n\n");
+        TokensApi tokensApi = new TokensApi(pvaultClient);
+        String token = tokenizeData(customerIds.get(0), tokensApi);
+
+        detokenizeToken(tokensApi, token);
+
+        print("\n\n== Step 6: Query your data ==\n\n");
+        queryAllObjectsWithPageSize(objectsApi);
+        queryPropertiesOfObjectsById(objectsApi, customerIds.get(0));
+        getTransformedPropertiesOfObjects(objectsApi, customerIds.get(0));
+
+        print("\n\n== Step 7: Delete data ==\n\n");
+        deleteToken(tokensApi, token);
+        deleteObject(objectsApi, customerIds.get(0));
+
+        print("Done!\n");
     }
 }

--- a/java/src/main/java/PvaultGettingStarted.java
+++ b/java/src/main/java/PvaultGettingStarted.java
@@ -22,6 +22,41 @@ public class PvaultGettingStarted {
     public static final String NO_TRANSACTION_ID = null; // Transaction ID is only relevant for advanced usage
     public static final int PVAULT_ADDRESS = 8123;
 
+    public void run() throws Exception {
+
+        print("\n\n== Steps 1 + 2: Connect to Piiano vault and check status ==\n\n");
+        ApiClient pvaultClient = getApiClient();
+        checkPvaultStatus(pvaultClient);
+
+        print("\n\n== Step 3: Create a collection ==\n\n");
+        CollectionsApi collectionsApi = new CollectionsApi(pvaultClient);
+        CollectionPropertiesApi collectionpropapi = new CollectionPropertiesApi(pvaultClient);
+        // deleteCollection(collectionsApi);
+        verifyNoCollections(collectionpropapi);
+        createCollection(collectionsApi);
+
+        print("\n\n== Step 4: Add data ==\n\n");
+        ObjectsApi objectsApi = new ObjectsApi(pvaultClient);
+        List<UUID> customerIds = addData(objectsApi);
+
+        print("\n\n== Step 5: Tokenize data ==\n\n");
+        TokensApi tokensApi = new TokensApi(pvaultClient);
+        String token = tokenizeData(customerIds.get(0), tokensApi);
+
+        detokenizeToken(tokensApi, token);
+
+        print("\n\n== Step 6: Query your data ==\n\n");
+        queryAllObjectsWithPageSize(objectsApi);
+        queryPropertiesOfObjectsById(objectsApi, customerIds.get(0));
+        getTransformedPropertiesOfObjects(objectsApi, customerIds.get(0));
+
+        print("\n\n== Step 7: Delete data ==\n\n");
+        deleteToken(tokensApi, token);
+        deleteObject(objectsApi, customerIds.get(0));
+
+        print("Done!\n");
+    }
+
     private static void checkPvaultStatus(ApiClient pvaultClient) throws ApiException {
 
         SystemApi systemApi = new SystemApi(pvaultClient);
@@ -262,40 +297,5 @@ public class PvaultGettingStarted {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-    }
-
-    public void run() throws Exception {
-
-        print("\n\n== Steps 1 + 2: Connect to Piiano vault and check status ==\n\n");
-        ApiClient pvaultClient = getApiClient();
-        checkPvaultStatus(pvaultClient);
-
-        print("\n\n== Step 3: Create a collection ==\n\n");
-        CollectionsApi collectionsApi = new CollectionsApi(pvaultClient);
-        CollectionPropertiesApi collectionpropapi = new CollectionPropertiesApi(pvaultClient);
-        // deleteCollection(collectionsApi);
-        verifyNoCollections(collectionpropapi);
-        createCollection(collectionsApi);
-
-        print("\n\n== Step 4: Add data ==\n\n");
-        ObjectsApi objectsApi = new ObjectsApi(pvaultClient);
-        List<UUID> customerIds = addData(objectsApi);
-
-        print("\n\n== Step 5: Tokenize data ==\n\n");
-        TokensApi tokensApi = new TokensApi(pvaultClient);
-        String token = tokenizeData(customerIds.get(0), tokensApi);
-
-        detokenizeToken(tokensApi, token);
-
-        print("\n\n== Step 6: Query your data ==\n\n");
-        queryAllObjectsWithPageSize(objectsApi);
-        queryPropertiesOfObjectsById(objectsApi, customerIds.get(0));
-        getTransformedPropertiesOfObjects(objectsApi, customerIds.get(0));
-
-        print("\n\n== Step 7: Delete data ==\n\n");
-        deleteToken(tokensApi, token);
-        deleteObject(objectsApi, customerIds.get(0));
-
-        print("Done!\n");
     }
 }

--- a/java/src/test/java/collections/CollectionsClient.java
+++ b/java/src/test/java/collections/CollectionsClient.java
@@ -1,9 +1,10 @@
 package collections;
 
-import org.openapitools.client.ApiClient;
-import org.openapitools.client.ApiException;
-import org.openapitools.client.api.CollectionsApi;
-import org.openapitools.client.model.*;
+import com.piiano.vault.client.openapi.ApiClient;
+import com.piiano.vault.client.openapi.ApiException;
+import com.piiano.vault.client.openapi.CollectionsApi;
+import com.piiano.vault.client.openapi.model.Collection;
+import com.piiano.vault.client.openapi.model.Property;
 
 import static common.Client.JSON;
 import static common.Client.NO_OPTIONS;
@@ -14,14 +15,6 @@ public class CollectionsClient {
 
     public CollectionsClient(ApiClient client) {
         collections = new CollectionsApi(client);
-    }
-
-    public Collection add(Collection collection) throws ApiException {
-        return collections.addCollection(collection, JSON, NO_OPTIONS);
-    }
-
-    public void delete(String collectionName) throws ApiException {
-        collections.deleteCollection(collectionName);
     }
 
     public static Property createProp(
@@ -37,5 +30,13 @@ public class CollectionsClient {
         property.setIsEncrypted(isEncrypted);
         property.isIndex(isIndex);
         return property;
+    }
+
+    public Collection add(Collection collection) throws ApiException {
+        return collections.addCollection(collection, JSON, NO_OPTIONS);
+    }
+
+    public void delete(String collectionName) throws ApiException {
+        collections.deleteCollection(collectionName);
     }
 }

--- a/java/src/test/java/common/ApiError.java
+++ b/java/src/test/java/common/ApiError.java
@@ -2,7 +2,7 @@ package common;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.openapitools.client.ApiException;
+import com.piiano.vault.client.openapi.ApiException;
 
 import javax.ws.rs.core.Response;
 import java.util.HashMap;
@@ -13,7 +13,8 @@ public class ApiError {
     public String message;
     public HashMap<String, String> context;
 
-    public ApiError(){}
+    public ApiError() {
+    }
 
     private ApiError(Response.Status status, String error_code, String message, HashMap<String, String> context) {
         this.status = status;

--- a/java/src/test/java/common/ApiMethod.java
+++ b/java/src/test/java/common/ApiMethod.java
@@ -1,6 +1,6 @@
 package common;
 
-import org.openapitools.client.ApiException;
+import com.piiano.vault.client.openapi.ApiException;
 
 @FunctionalInterface
 public interface ApiMethod {

--- a/java/src/test/java/common/Client.java
+++ b/java/src/test/java/common/Client.java
@@ -1,7 +1,7 @@
 package common;
 
-import org.openapitools.client.ApiClient;
-import org.openapitools.client.Configuration;
+import com.piiano.vault.client.openapi.ApiClient;
+import com.piiano.vault.client.openapi.Configuration;
 
 import java.util.Set;
 
@@ -10,10 +10,10 @@ import static java.util.Collections.emptySet;
 public class Client {
 
     public static final int DEFAULT_PVAULT_PORT = 8123;
-    public static final String NO_ADHOC_REASON = "";
+    public static final String NO_ADHOC_REASON = null;
     public static final String APP_FUNCTIONALITY_REASON = "AppFunctionality";
     public static final String USE_DEFAULT_TTL = "";
-    public static final String NO_TRANSACTION_ID=""; // Transaction ID is only relevant for advanced usage
+    public static final String NO_TRANSACTION_ID = null; // Transaction ID is only relevant for advanced usage
     public static final Boolean RELOAD_CACHE = false;
     public static final String JSON = "json";
     public static final Set<String> NO_OPTIONS = emptySet();

--- a/java/src/test/java/common/CollectionSetup.java
+++ b/java/src/test/java/common/CollectionSetup.java
@@ -1,10 +1,10 @@
 package common;
 
 import collections.CollectionsClient;
+import com.piiano.vault.client.openapi.ApiClient;
+import com.piiano.vault.client.openapi.ApiException;
+import com.piiano.vault.client.openapi.model.Collection;
 import objects.ObjectsClient;
-import org.openapitools.client.ApiClient;
-import org.openapitools.client.ApiException;
-import org.openapitools.client.model.Collection;
 
 import javax.ws.rs.core.Response;
 import java.util.ArrayList;
@@ -18,16 +18,15 @@ public class CollectionSetup {
     private final CollectionsClient collectionsClient = new CollectionsClient(apiClient);
     private final ObjectsClient objectsClient = new ObjectsClient(apiClient);
     private final String collectionName = "customers";
-
-    private Collection collection;
     public Map<UUID, Map<String, Object>> mapObjectIdToObjectFields;
+    private Collection collection;
     private ArrayList<UUID> objectIds;
 
-    public ArrayList<UUID> getObjectIds(){
+    public ArrayList<UUID> getObjectIds() {
         return objectIds;
     }
 
-    public Collection getCollection(){
+    public Collection getCollection() {
         return collection;
     }
 
@@ -63,7 +62,7 @@ public class CollectionSetup {
 
     // Read back the objects and verify that there were all inserted correctly.
     private void assertObjectsWereInserted(
-        Map<UUID, Map<String, Object>> mapObjectIdToObjectFields) throws ApiException {
+            Map<UUID, Map<String, Object>> mapObjectIdToObjectFields) throws ApiException {
 
         // get all properties (props == null)
         var objects = objectsClient.get(collectionName, objectIds, null).getResults();

--- a/java/src/test/java/common/ErrorHelper.java
+++ b/java/src/test/java/common/ErrorHelper.java
@@ -1,8 +1,8 @@
 package common;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.piiano.vault.client.openapi.ApiException;
 import org.junit.jupiter.api.Assertions;
-import org.openapitools.client.ApiException;
 
 public class ErrorHelper {
 

--- a/java/src/test/java/common/Factory.java
+++ b/java/src/test/java/common/Factory.java
@@ -1,7 +1,7 @@
 package common;
 
 import collections.CollectionsClient;
-import org.openapitools.client.model.Collection;
+import com.piiano.vault.client.openapi.model.Collection;
 
 import java.util.HashMap;
 import java.util.List;
@@ -15,45 +15,45 @@ public class Factory {
         collection.setType(Collection.TypeEnum.PERSONS);
 
         collection.addPropertiesItem(
-            CollectionsClient.createProp("ssn", "SSN", "Social security number",
-                true, false, true, false));
+                CollectionsClient.createProp("ssn", "SSN", "Social security number",
+                        true, false, true, false));
 
         collection.addPropertiesItem(
-            CollectionsClient.createProp("email", "EMAIL", "EMAIL",
-                false, false, true, false));
+                CollectionsClient.createProp("email", "EMAIL", "EMAIL",
+                        false, false, true, false));
 
         collection.addPropertiesItem(
-            CollectionsClient.createProp("phone_number", "PHONE_NUMBER", "PHONE_NUMBER",
-                false, true, true, false));
+                CollectionsClient.createProp("phone_number", "PHONE_NUMBER", "PHONE_NUMBER",
+                        false, true, true, false));
 
         collection.addPropertiesItem(
-            CollectionsClient.createProp("zip_code_us", "ZIP_CODE_US", "ZIP_CODE_US",
-                false, true, true, false));
+                CollectionsClient.createProp("zip_code_us", "ZIP_CODE_US", "ZIP_CODE_US",
+                        false, true, true, false));
         return collection;
     }
 
     public static List<Map<String, Object>> createObjects() {
         return List.of(
-            createObject(
-                "123-12-1234",
-                "john@somemail.com",
-                "+1121212123",
-                "12345"),
-            createObject(
-                "123-12-1235",
-                "mary@somemail.com",
-                "+1121212124",
-                "12345"),
-            createObject(
-                "123-12-1236",
-                "eric@somemail.com",
-                "+1121212125",
-                "12345")
+                createObject(
+                        "123-12-1234",
+                        "john@somemail.com",
+                        "+1121212123",
+                        "12345"),
+                createObject(
+                        "123-12-1235",
+                        "mary@somemail.com",
+                        "+1121212124",
+                        "12345"),
+                createObject(
+                        "123-12-1236",
+                        "eric@somemail.com",
+                        "+1121212125",
+                        "12345")
         );
     }
 
     private static Map<String, Object> createObject(
-        String ssn, String email, String phoneNumber, String zipCodeUS) {
+            String ssn, String email, String phoneNumber, String zipCodeUS) {
 
         Map<String, Object> objectDetails = new HashMap<>();
         objectDetails.put("ssn", ssn);

--- a/java/src/test/java/common/Helpers.java
+++ b/java/src/test/java/common/Helpers.java
@@ -10,20 +10,20 @@ public class Helpers {
     // If keys is null asserts that the maps are equal.
     // If keys is not null asserts that both maps have equal values for each of the keys
     public static void assertValuesOfKeysEqual(
-        Map<String, Object> expectedFields,
-        Map<String, Object> actualFields,
-        List<String> keys) {
+            Map<String, Object> expectedFields,
+            Map<String, Object> actualFields,
+            List<String> keys) {
 
         Assertions.assertTrue(
-            Helpers.areValuesOfKeysEqual(actualFields, expectedFields, keys));
+                Helpers.areValuesOfKeysEqual(actualFields, expectedFields, keys));
     }
 
     // If keys is null returns true iff the maps are equal.
     // If keys is not null returns true iff both maps have equal values for each of the keys
     public static <K, V> boolean areValuesOfKeysEqual(
-        Map<K, V> map1,
-        Map<K, V> map2,
-        List<K> keys) {
+            Map<K, V> map1,
+            Map<K, V> map2,
+            List<K> keys) {
 
         if (keys == null) {
             return map1.equals(map2);

--- a/java/src/test/java/objects/ObjectsClient.java
+++ b/java/src/test/java/objects/ObjectsClient.java
@@ -1,12 +1,15 @@
 package objects;
 
-import org.openapitools.client.ApiClient;
-import org.openapitools.client.ApiException;
-import org.openapitools.client.api.ObjectsApi;
-import org.openapitools.client.model.ObjectFieldsPage;
-import org.openapitools.client.model.ObjectID;
+import com.piiano.vault.client.openapi.ApiClient;
+import com.piiano.vault.client.openapi.ApiException;
+import com.piiano.vault.client.openapi.ObjectsApi;
+import com.piiano.vault.client.openapi.model.ObjectFieldsPage;
+import com.piiano.vault.client.openapi.model.ObjectID;
 
-import java.util.*;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 import static common.Client.*;
 

--- a/java/src/test/java/tokens/DetokenizeResult.java
+++ b/java/src/test/java/tokens/DetokenizeResult.java
@@ -1,6 +1,6 @@
 package tokens;
 
-import org.openapitools.client.model.DetokenizedToken;
+import com.piiano.vault.client.openapi.model.DetokenizedToken;
 
 import java.util.List;
 

--- a/java/src/test/java/tokens/RotateResult.java
+++ b/java/src/test/java/tokens/RotateResult.java
@@ -1,8 +1,9 @@
 package tokens;
 
-import org.openapitools.client.model.TokenValue;
+import com.piiano.vault.client.openapi.model.TokenValue;
 
-import java.util.*;
+import java.util.Map;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 // RotateResult contains all the information returned by the rotate API method.
@@ -22,15 +23,15 @@ class RotateResult {
     public TokenizeResult rotate(TokenizeResult tokenizeResult) {
         var objectIds = tokenizeResult.getObjectIds();
         var newTokenValues = objectIds.stream().map(
-            objectId -> {
-                var oldTokenId = tokenizeResult.getTokenId(objectId);
-                var newTokenId = oldTokenIdToNewTokenId.get(oldTokenId);
-                return toTokenValue(newTokenId);
-            }
+                objectId -> {
+                    var oldTokenId = tokenizeResult.getTokenId(objectId);
+                    var newTokenId = oldTokenIdToNewTokenId.get(oldTokenId);
+                    return toTokenValue(newTokenId);
+                }
         ).collect(Collectors.toList());
         return new TokenizeResult(
-            objectIds,              // use original object objectIds
-            newTokenValues);
+                objectIds,              // use original object objectIds
+                newTokenValues);
     }
 
     TokenValue toTokenValue(String tokenId) {

--- a/java/src/test/java/tokens/SearchResult.java
+++ b/java/src/test/java/tokens/SearchResult.java
@@ -1,7 +1,7 @@
 package tokens;
 
-import org.openapitools.client.model.TokenMetadata;
-import org.openapitools.client.model.TokenRefMetadata;
+import com.piiano.vault.client.openapi.model.TokenMetadata;
+import com.piiano.vault.client.openapi.model.TokenRefMetadata;
 
 import java.util.List;
 import java.util.Map;
@@ -19,7 +19,7 @@ class SearchResult {
         for (var datum : tokenMetadata) {
             var tokenId = datum.getTokenId();
             var objectIds = datum.getTokens().stream().map(
-                TokenRefMetadata::getObjectId
+                    TokenRefMetadata::getObjectId
             ).collect(Collectors.toList());
 
             tokenIdToObjectIds.put(tokenId, objectIds);

--- a/java/src/test/java/tokens/TokenDefinition.java
+++ b/java/src/test/java/tokens/TokenDefinition.java
@@ -4,9 +4,9 @@ import java.util.List;
 import java.util.UUID;
 
 public record TokenDefinition(
-    List<String> tokenIds,
-    List<UUID> objectIds,
-    List<String> tags
+        List<String> tokenIds,
+        List<UUID> objectIds,
+        List<String> tags
 ) {
     static TokenDefinition fromTokenIds(List<String> tokenIds) {
         return new TokenDefinition(tokenIds, null, null);

--- a/java/src/test/java/tokens/TokenizeResult.java
+++ b/java/src/test/java/tokens/TokenizeResult.java
@@ -1,6 +1,6 @@
 package tokens;
 
-import org.openapitools.client.model.TokenValue;
+import com.piiano.vault.client.openapi.model.TokenValue;
 
 import java.util.*;
 

--- a/java/src/test/java/tokens/TokensClient.java
+++ b/java/src/test/java/tokens/TokensClient.java
@@ -1,11 +1,14 @@
 package tokens;
 
-import org.openapitools.client.ApiClient;
-import org.openapitools.client.ApiException;
-import org.openapitools.client.api.TokensApi;
-import org.openapitools.client.model.*;
+import com.piiano.vault.client.openapi.ApiClient;
+import com.piiano.vault.client.openapi.ApiException;
+import com.piiano.vault.client.openapi.TokensApi;
+import com.piiano.vault.client.openapi.model.*;
 
-import java.util.*;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static common.Client.*;
 import static java.util.Collections.emptyList;
@@ -20,8 +23,8 @@ public class TokensClient {
 
     public List<TokenValue> tokenize(String collectionName, List<TokenizeRequest> tokenizeRequest) throws ApiException {
         return collections.tokenize(collectionName, APP_FUNCTIONALITY_REASON,
-                                    tokenizeRequest, USE_DEFAULT_TTL, NO_TRANSACTION_ID,
-                                    NO_ADHOC_REASON, RELOAD_CACHE);
+                tokenizeRequest, USE_DEFAULT_TTL, NO_TRANSACTION_ID,
+                NO_ADHOC_REASON, RELOAD_CACHE);
     }
 
     public List<DetokenizedToken> detokenize(String collectionName, TokenDefinition tokens, boolean includeMetadata, boolean archived) throws ApiException {


### PR DESCRIPTION
- Update the getting started to use the Java SDK instead of regenerating it.
- Run "Organize imports" and "format code" on the project
- Fix tests and flow to not send an empty value for `adhoc_reason` now with the new cellotape runtime validations.